### PR TITLE
await installExtension to surface errors

### DIFF
--- a/src/commands/extension/install.ts
+++ b/src/commands/extension/install.ts
@@ -13,6 +13,6 @@ export default class Install extends BaseCommand {
   };
 
   async run() {
-    installExtension(this.api, this.flags.dumpCode);
+    await installExtension(this.api, this.flags.dumpCode);
   }
 }


### PR DESCRIPTION
Errors when reading package.json are otherwise hidden behind an unhandled promise rejection
