### PR TITLE
DEVELOP-526: Further extension project setup

### DIFF
--- a/src/utils/packageInfo.ts
+++ b/src/utils/packageInfo.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+let _packageRoot: string;
+export function packageRoot() {
+  if (_packageRoot) return _packageRoot;
+
+  let searchDir = path.resolve(__dirname);
+
+  while (path.dirname(searchDir) !== searchDir) {
+    try {
+      if (fs.statSync(path.join(searchDir, 'package.json')).isFile()) {
+        _packageRoot = searchDir;
+        return searchDir;
+      }
+    } catch (err) {}
+
+    searchDir = path.dirname(searchDir);
+  }
+
+  throw new Error('Cannot find package root');
+}
+
+export function packageInfo() {
+  return JSON.parse(
+    fs.readFileSync(path.join(packageRoot(), 'package.json')) as any
+  );
+}


### PR DESCRIPTION
Add extension setup for package.json schema and ts types

Copies the aha.d.ts and schema.json files into the new extension. This sets up the aha-cli as a dummy dependency so that it will be linked to the current version, but doesn't require running npm or yarn install. If those commands are run then the full package will take over without interruption.

This also sets up a tsconfig.json file which both activates the ts autocompletion using the aha-cli types file AND fills in the correct settings for aha-cli to compile ts files if the user writes those instead of js files (as already supported by our esbuild config).