### PR TITLE
interpolate version into build file name

### DIFF
--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -24,7 +24,7 @@ export function identifierFromConfiguration(configuration: any) {
 }
 
 function fileNameFromConfiguration(configuration: any) {
-  return configuration.name.replace('@', '-').replace('/', '-');
+  return `${identifierFromConfiguration(configuration)}-v${configuration.version}`;
 }
 
 /**


### PR DESCRIPTION
this will let us point one-click importer installs at a specific version, 
which will in turn let us handle importer-api changes more clearly.

also switching to the identifier as the file name makes it straightforward to pattern-match that it has been installed already.