### PR TITLE
DEVELOP-619: Include version number in extension:build file name

### DIFF
--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -25,7 +25,9 @@ export function identifierFromConfiguration(configuration: any) {
 }
 
 function fileNameFromConfiguration(configuration: any) {
-  return configuration.name.replace('@', '-').replace('/', '-');
+  return [configuration.name.replace('@', '-'), `v${configuration.version}`]
+    .join('-')
+    .replace('/', '-');
 }
 
 /**


### PR DESCRIPTION
When building the extension file, we should include the extension's version number for simpler uploading.