### PR TITLE
DEVELOP-632: Do not treat .ts files as .tsx files

### DIFF
--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -256,7 +256,7 @@ async function prepareScript(
       write: false,
       sourcemap: 'external',
       sourcesContent: false,
-      loader: { '.js': 'jsx', '.ts': 'tsx' },
+      loader: { '.js': 'jsx' },
       define: {
         'process.env.NODE_ENV': '"production"',
       },


### PR DESCRIPTION
There's a difference between .ts and .tsx files that does not exist between .js and .jsx files. .ts files can use generics like `function(something:T) { return something; }` but esbuild interprets the generic as JSX with `loader: '.ts':'.tsx'`

In my opinion this behaviour will cause a lot of confusion. If people are developing with typescript they'll already be used to the ts/tsx pattern.