### PR TITLE
DEVELOP-700: extension:watch should always do an update on startup

### DIFF
--- a/src/commands/extension/watch.ts
+++ b/src/commands/extension/watch.ts
@@ -4,7 +4,7 @@ import * as chokidar from 'chokidar';
 import { installExtension } from '../../utils/extension-utils';
 
 const WAIT_TIMEOUT = 250;
-export default class Create extends BaseCommand {
+export default class Watch extends BaseCommand {
   static needsAuth = true;
 
   static description =
@@ -24,6 +24,7 @@ export default class Create extends BaseCommand {
   performingInstall = false;
 
   async run() {
+    await this.performInstall();
     this.log('Watching for changes in the current directory ...');
 
     chokidar


### PR DESCRIPTION
extension:watch waits until the first change to update the extension. If I've changed the extension without running watch, it will wait until the next change before updating the extension. This seems weird.

We should always do an initial install with the current state of the code before watching. This also seems more consistent with watchers I've used before.