### PR TITLE
Rename command classes to match command names

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -19,7 +19,7 @@ interface TokenInfo {
   email: string;
 }
 
-class LoginCommand extends BaseCommand {
+class Login extends BaseCommand {
   static description = `Login to Aha! and save credentials for other commands
 Credentials are saved in ~/.netrc`;
 
@@ -97,4 +97,4 @@ Credentials are saved in ~/.netrc`;
   }
 }
 
-export default LoginCommand;
+export default Login;

--- a/src/commands/extension/add-contribution.ts
+++ b/src/commands/extension/add-contribution.ts
@@ -5,7 +5,7 @@ import * as inquirer from 'inquirer';
 import templates from '../../utils/templates';
 import questions from '../../utils/questions';
 
-export default class Create extends BaseCommand {
+export default class AddContribution extends BaseCommand {
   static description = 'Add a contribution to an extension';
 
   static flags = {

--- a/src/commands/extension/build.ts
+++ b/src/commands/extension/build.ts
@@ -2,7 +2,7 @@ import BaseCommand from '../../base';
 import { flags } from '@oclif/command';
 import { buildExtension } from '../../utils/extension-utils';
 
-export default class Install extends BaseCommand {
+export default class Build extends BaseCommand {
   static description =
     'Build an extension into a zip file for ease of distribution';
 


### PR DESCRIPTION
Seems like it's easy for these names to get out of sync with copypasta. Not consequential, but can become slightly confusing when moving between commands.