### PR TITLE
resolve lodash to a patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "ts-node": "8.10.2",
     "typescript": "3.9.5"
   },
+  "resolutions": {
+    "lodash": "4.17.21"
+  },
   "engines": {
     "node": ">=11.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,12 +1950,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
I ran yarn audit while reviewing https://github.com/aha-app/aha-cli/pull/38 and found two lodash issues  https://www.npmjs.com/advisories/1005365     https://www.npmjs.com/advisories/1006094        

this resolution patches them 