### PR TITLE
DEVELOP-1283 Append requested subdomain to login query

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -40,13 +40,17 @@ Credentials are saved in ~/.netrc`;
     process.stderr.write(
       'Opening browser to login to Aha! and authorize the CLI\n'
     );
-    const cp = await open(
-      `${this.flags.authServer}/external/cli/start?cli_token=${cliToken}`,
-      {
-        app: this.flags.browser,
-        wait: false,
-      }
-    );
+
+    let url = `${this.flags.authServer}/external/cli/start?cli_token=${cliToken}`;
+
+    if (this.flags.subdomain) {
+      url += `&requested_domain=${this.flags.subdomain}`;
+    }
+
+    const cp = await open(url, {
+      app: this.flags.browser,
+      wait: false,
+    });
     cp.on('error', err => {
       ux.warn(err);
       ux.warn('Cannot open browser');


### PR DESCRIPTION
When authenticating with an Aha! user using SSO the account chooser cannot be shown, so the cli must send the requested subdomain instead.
