### PR TITLE
ADT-353: Add more aha.imports for our MVC packages

### DIFF
--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -12,7 +12,12 @@ import { httpPlugin } from './esbuild-http';
 import { SimpleCache } from './simple-cache';
 
 const REACT_JSX = 'React.createElement';
-const EXTERNALS = ['react', 'react-dom'];
+const EXTERNALS = [
+  'react',
+  'react-dom',
+  '@aha-app/mvc',
+  '@aha-app/react-easy-state',
+];
 
 export function readConfiguration() {
   try {


### PR DESCRIPTION
Add some more packages to the `EXTERNALS` list

These packages are often used by extensions, and can increase the size of the extension scripts significantly. We should include them in the list of shared externals.