### PR TITLE
Added 'javascripts/async_modules' to esbuild externals

### DIFF
--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -12,7 +12,7 @@ import { httpPlugin } from './esbuild-http';
 import { SimpleCache } from './simple-cache';
 
 const REACT_JSX = 'React.createElement';
-const EXTERNALS = ['react', 'react-dom'];
+const EXTERNALS = ['react', 'react-dom', 'javascripts/async_modules'];
 
 export function readConfiguration() {
   try {


### PR DESCRIPTION
In https://github.com/aha-app/aha-app/pull/24672 we exposed `javascripts/async_modules` to the `window.require` global for easier loading.

This PR allows extensions to use methods from `javascripts/async_modules` by marking it as a [esbuild external module](https://esbuild.github.io/api/#external). 

e.g.:

```
declare module 'javascripts/async_modules' {
  export function loadMomentTimezone(): Promise<typeof moment>;
}
...
import { loadMomentTimezone } from 'javascripts/async_modules';
```

Before
```
Compiling...
 > src/**/**.ts: error: Could not resolve "javascripts/async_modules" (mark it as external to exclude it from the bundle)
    90 │ ...omentTimezone } = require('javascripts/async_modules');
       ╵                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After:
```
Compiling... done
```
