### PR TITLE
ADT-566: Add lodash to the external libraries

### DIFF
--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -12,7 +12,7 @@ import { httpPlugin } from './esbuild-http';
 import { SimpleCache } from './simple-cache';
 
 const REACT_JSX = 'React.createElement';
-const EXTERNALS = ['react', 'react-dom'];
+const EXTERNALS = ['react', 'react-dom', 'lodash'];
 
 export function readConfiguration() {
   try {


### PR DESCRIPTION
<p>We expose/import some external libraries from the main <code>aha-app</code> bundle to avoid very large extensions. We should add <code>lodash</code> to the list as well.</p>


- Add `lodash` to the external libraries