### PR TITLE
DEVELOP-768 Update create contribution script to allow secret extension settings

### DIFF
--- a/src/utils/questions.ts
+++ b/src/utils/questions.ts
@@ -15,7 +15,7 @@ export async function getContributionFromQuestions() {
       recordTypes: answers.recordTypes,
       handles: answers.handles,
       description: answers.description,
-      default: answers.default,
+      default: (answers.type === 'secret' ? null : answers.default),
       type: answers.type,
       scope: answers.scope,
     },
@@ -169,7 +169,7 @@ export const contributionQuestions = [
     type: 'list',
     name: 'type',
     message: 'Enter the type for your setting:',
-    choices: ['boolean', 'color', 'string', 'number'],
+    choices: ['boolean', 'color', 'string', 'number', 'secret'],
     default: 'color',
     when: (answers: StringAnswers) => answers.contributionType === 'settings',
   },
@@ -187,6 +187,8 @@ export const contributionQuestions = [
           return 'Description';
         case 'number':
           return 'Choose a number';
+        case 'secret':
+          return 'Authentication token';
       }
     },
     when: (answers: StringAnswers) => answers.contributionType === 'settings',
@@ -207,7 +209,7 @@ export const contributionQuestions = [
           return '42';
       }
     },
-    when: (answers: StringAnswers) => answers.contributionType === 'settings',
+    when: (answers: StringAnswers) => answers.contributionType === 'settings' && answers.type !== 'secret',
   },
   {
     type: 'checkbox',

--- a/src/utils/questions.ts
+++ b/src/utils/questions.ts
@@ -15,7 +15,7 @@ export async function getContributionFromQuestions() {
       recordTypes: answers.recordTypes,
       handles: answers.handles,
       description: answers.description,
-      default: (answers.type === 'secret' ? null : answers.default),
+      default: answers.type === 'secret' ? null : answers.default,
       type: answers.type,
       scope: answers.scope,
     },
@@ -209,7 +209,8 @@ export const contributionQuestions = [
           return '42';
       }
     },
-    when: (answers: StringAnswers) => answers.contributionType === 'settings' && answers.type !== 'secret',
+    when: (answers: StringAnswers) =>
+      answers.contributionType === 'settings' && answers.type !== 'secret',
   },
   {
     type: 'checkbox',


### PR DESCRIPTION
[Main PR](https://github.com/aha-app/aha-app/pull/36916)

This just updates the extension questionnaire so you can make a secret from the CLI if you really want to. I'm not sure it's very necessary, but no harm in adding the functionality (it's just updating the questions, since the schema is pulled from Aha's CDN anyway).

Potentially can hold off on releasing this until the TestRail Extension is further along, as there will be further additions to what can be built for extensions as part of that work.