### PR TITLE
DEVELOP-2300-4: extension:watch now ignores node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aha-cli",
   "description": "Command line interface for Aha! (www.aha.io)",
-  "version": "1.17.0",
+  "version": "2.0.0",
   "author": "Aha! (support@aha.io)",
   "bin": {
     "aha": "./bin/run"
@@ -14,7 +14,7 @@
     "@oclif/plugin-help": "5.2.7",
     "@types/inquirer": "7.3.1",
     "chalk": "4.1.0",
-    "chokidar": "3.5.3",
+    "chokidar": "4.0.3",
     "crypto": "1.0.1",
     "esbuild": "0.11.2",
     "form-data": "3.0.0",
@@ -25,7 +25,7 @@
     "tslib": "1.13.0"
   },
   "devDependencies": {
-    "@types/node": "10.17.24",
+    "@types/node": "20.14.0",
     "eslint": "5.16.0",
     "eslint-config-oclif": "3.1.0",
     "eslint-config-oclif-typescript": "0.1.0",
@@ -35,7 +35,7 @@
     "oclif": "3.7.0",
     "prettier": "2.2.1",
     "ts-node": "8.10.2",
-    "typescript": "3.9.5"
+    "typescript": "5.9.3"
   },
   "resolutions": {
     "lodash": "4.17.21"

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -18,6 +18,12 @@ interface TokenInfo {
   email: string;
 }
 
+interface HttpStatusError {
+  http?: {
+    statusCode?: number;
+  };
+}
+
 class Login extends BaseCommand {
   static description = `Login to Aha! and save credentials for other commands
 Credentials are saved in ~/.netrc`;
@@ -70,7 +76,8 @@ Credentials are saved in ~/.netrc`;
 
         break;
       } catch (error) {
-        if (!error.http || error.http.statusCode !== 408) throw error;
+        const httpError = error as HttpStatusError;
+        if (!httpError.http || httpError.http.statusCode !== 408) throw error;
 
         // Sleep a little before polling again
         await new Promise(r => setTimeout(r, 1000));

--- a/src/commands/extension/watch.ts
+++ b/src/commands/extension/watch.ts
@@ -1,6 +1,6 @@
 import BaseCommand from '../../base';
 import { Flags } from '@oclif/core';
-import * as chokidar from 'chokidar';
+import chokidar from 'chokidar';
 import {
   fetchRemoteTypes,
   installExtension,
@@ -33,8 +33,8 @@ export default class Watch extends BaseCommand {
     await fetchRemoteTypes();
 
     chokidar
-      .watch('.', { ignoreInitial: true, ignored: '.git' })
-      .on('all', async (event, changedPath) => {
+      .watch('.', { ignoreInitial: true, ignored: ['.git', 'node_modules'] })
+      .on('all', async (_event, changedPath) => {
         if (this.timeoutHandle) {
           (this.changedPaths || []).push(changedPath);
           clearTimeout(this.timeoutHandle);
@@ -76,7 +76,8 @@ export default class Watch extends BaseCommand {
       await installExtension(this, false, this.flags.noCache);
     } catch (error) {
       // Do nothing if the compile fails
-      this.error(error.message, { exit: false });
+      const message = error instanceof Error ? error.message : String(error);
+      this.error(message, { exit: false });
     } finally {
       this.performingInstall = false;
     }

--- a/src/utils/esbuild-http.ts
+++ b/src/utils/esbuild-http.ts
@@ -61,15 +61,15 @@ const httpPlugin = (options: HttpPluginOptions): Plugin => {
       // handle the example import from unpkg.com but in reality this
       // would probably need to be more complex.
       build.onLoad({ filter: /.*/, namespace: 'http-url' }, async args => {
-        let contents: Buffer;
+        let contents: Uint8Array;
 
         if (cache && (await cache.has(args.path))) {
-          contents = await cache.get(args.path);
+          contents = new Uint8Array(await cache.get(args.path));
         } else {
-          contents = await fetch(args.path);
+          contents = new Uint8Array(await fetch(args.path));
 
           if (cache) {
-            await cache.set(args.path, contents);
+            await cache.set(args.path, Buffer.from(contents));
           }
         }
 

--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -14,11 +14,23 @@ import { SimpleCache } from './simple-cache';
 const REACT_JSX = 'React.createElement';
 const EXTERNALS = ['react', 'react-dom', 'lodash'];
 
+interface ApiErrorResponse {
+  errors?: { [index: string]: string[] };
+  error?: string;
+}
+
+interface HttpBodyError {
+  http?: {
+    body?: ApiErrorResponse;
+  };
+}
+
 export function readConfiguration() {
   try {
-    return JSON.parse(fs.readFileSync('package.json', { encoding: 'UTF-8' }));
+    return JSON.parse(fs.readFileSync('package.json', { encoding: 'utf-8' }));
   } catch (error) {
-    throw new Error(`Error loading package.json: ${error.message}`);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Error loading package.json: ${message}`);
   }
 }
 
@@ -121,9 +133,12 @@ export async function installExtension(
   } catch (error) {
     ux.action.stop('error');
 
-    if (error.http.body.errors) {
+    const httpError = error as HttpBodyError;
+    const body = httpError.http?.body;
+
+    if (body?.errors) {
       const errorTree = ux.tree();
-      const errors: { [index: string]: string[] } = error.http.body.errors;
+      const errors: { [index: string]: string[] } = body.errors;
       Object.keys(errors).forEach(identifier => {
         errorTree.insert(identifier);
         errors[identifier].forEach(error =>
@@ -133,7 +148,7 @@ export async function installExtension(
 
       errorTree.display();
     } else {
-      throw new Error(error.http.body.error);
+      throw new Error(body?.error || 'Extension upload failed');
     }
   }
 }

--- a/src/utils/simple-cache.ts
+++ b/src/utils/simple-cache.ts
@@ -8,9 +8,10 @@ import { promises as fs } from 'fs';
  * ```
  * const cache = await SimpleCache.create('path/to/cache/dir');
  * await cache.has('abc123'); // false
- * await cache.set('abc123', Buffer.concat('hello'));
+ * await cache.set('abc123', Buffer.from('hello'));
  * await cache.has('abc123'); // true
  * await cache.get('abc123'); // Buffer('hello')
+ * ```
  */
 export class SimpleCache {
   private location: string;
@@ -47,7 +48,7 @@ export class SimpleCache {
    */
   async set(url: string, data: Buffer) {
     const filePath = path.join(this.location, this.hash(url));
-    return fs.writeFile(filePath, data);
+    return fs.writeFile(filePath, new Uint8Array(data));
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,10 +922,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
   integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
-"@types/node@10.17.24":
-  version "10.17.24"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.24.tgz#c57511e3a19c4b5e9692bb2995c40a3a52167944"
-  integrity sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==
+"@types/node@20.14.0":
+  version "20.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.0.tgz#49ceec7b34f8621470cff44677fa9d461a477f17"
+  integrity sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^15.6.2":
   version "15.14.9"
@@ -1117,14 +1119,6 @@ ansicolors@~0.3.2:
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
   integrity sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==
 
-anymatch@~3.1.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
-  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
-
 "aproba@^1.0.3 || ^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
@@ -1246,11 +1240,6 @@ bin-links@^3.0.0:
     rimraf "^3.0.0"
     write-file-atomic "^4.0.0"
 
-binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
 binaryextensions@^4.15.0, binaryextensions@^4.16.0:
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-4.18.0.tgz#22aeada2d14de062c60e8ca59a504a5636a76ceb"
@@ -1280,7 +1269,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1462,20 +1451,12 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+chokidar@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
+    readdirp "^4.0.1"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -2487,11 +2468,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -2589,7 +2565,7 @@ github-username@^6.0.0:
   dependencies:
     "@octokit/rest" "^18.0.6"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2969,13 +2945,6 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
 is-builtin-module@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
@@ -3029,7 +2998,7 @@ is-generator-function@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -3710,7 +3679,7 @@ normalize-package-data@^3.0.3:
     semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
+normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -4105,7 +4074,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -4309,12 +4278,10 @@ readdir-scoped-modules@^1.1.0:
     graceful-fs "^4.1.2"
     once "^1.3.0"
 
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
+readdirp@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -4999,10 +4966,15 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@3.9.5:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+typescript@5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unique-filename@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
 `extension:watch` will now ignore node_modules.   Bumped package version as this is technically a breaking change, but `extension:watch` is broken at least in the zendesk extension without this.   

Note its possible to test this locally like so
`yarn pack`

`npx --yes --package /{path-to-built.tgz}.tgz aha extension:watch`

- Update [chokidar to v4](https://github.com/paulmillr/chokidar?tab=readme-ov-file#changelog) 
- This [required updates](https://github.com/paulmillr/chokidar/issues/1416) to node types
- Updated node types required a pass through to resolve TS errors 
