### PR TITLE
ADT-1040-2: Exclude peer dependencies when building extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-aha-cli
-=======
+# aha-cli
 
 Command line interface for working with [Aha!](https://www.aha.io).
 
-Currently supported commands are for creating and managing extensions. 
+Currently supported commands are for creating and managing extensions.
 
 <!-- toc -->
+* [aha-cli](#aha-cli)
 * [Usage](#usage)
 * [Commands](#commands)
+* [Development](#development)
 <!-- tocstop -->
+
 # Usage
+
 ```sh-session
 $ npm install -g aha-cli
 $ aha auth:login
@@ -19,7 +22,9 @@ Create a new extension...
 $ aha extension:install
 Install the extension into your Aha! account...
 ```
+
 # Commands
+
 <!-- commands -->
 * [`aha auth:check`](#aha-authcheck)
 * [`aha auth:login`](#aha-authlogin)
@@ -47,7 +52,7 @@ DESCRIPTION
   Check if the stored credentials work
 ```
 
-_See code: [src/commands/auth/check.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/auth/check.ts)_
+_See code: [src/commands/auth/check.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/auth/check.ts)_
 
 ## `aha auth:login`
 
@@ -67,7 +72,7 @@ DESCRIPTION
   Credentials are saved in ~/.netrc
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/auth/login.ts)_
 
 ## `aha extension:add-contribution`
 
@@ -84,7 +89,7 @@ DESCRIPTION
   Add a contribution to an extension
 ```
 
-_See code: [src/commands/extension/add-contribution.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/extension/add-contribution.ts)_
+_See code: [src/commands/extension/add-contribution.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/extension/add-contribution.ts)_
 
 ## `aha extension:build`
 
@@ -102,7 +107,7 @@ DESCRIPTION
   Build an extension into a zip file for ease of distribution
 ```
 
-_See code: [src/commands/extension/build.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/extension/build.ts)_
+_See code: [src/commands/extension/build.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/extension/build.ts)_
 
 ## `aha extension:create`
 
@@ -119,7 +124,7 @@ DESCRIPTION
   Create an example extension
 ```
 
-_See code: [src/commands/extension/create.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/extension/create.ts)_
+_See code: [src/commands/extension/create.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/extension/create.ts)_
 
 ## `aha extension:install`
 
@@ -138,7 +143,7 @@ DESCRIPTION
   Install the extension from the current directory
 ```
 
-_See code: [src/commands/extension/install.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/extension/install.ts)_
+_See code: [src/commands/extension/install.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/extension/install.ts)_
 
 ## `aha extension:tail`
 
@@ -155,7 +160,7 @@ DESCRIPTION
   Live tail extension logs
 ```
 
-_See code: [src/commands/extension/tail.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/extension/tail.ts)_
+_See code: [src/commands/extension/tail.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/extension/tail.ts)_
 
 ## `aha extension:uninstall`
 
@@ -172,7 +177,7 @@ DESCRIPTION
   Uninstall the extension in the current directory
 ```
 
-_See code: [src/commands/extension/uninstall.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/extension/uninstall.ts)_
+_See code: [src/commands/extension/uninstall.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/extension/uninstall.ts)_
 
 ## `aha extension:watch`
 
@@ -190,7 +195,7 @@ DESCRIPTION
   Watch the current directory for changes and install the extension each time a file changes
 ```
 
-_See code: [src/commands/extension/watch.ts](https://github.com/aha-app/aha-cli/blob/v1.17.0/src/commands/extension/watch.ts)_
+_See code: [src/commands/extension/watch.ts](https://github.com/aha-app/aha-cli/blob/v3.0.0/src/commands/extension/watch.ts)_
 
 ## `aha help [COMMANDS]`
 
@@ -212,3 +217,30 @@ DESCRIPTION
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.2.7/src/commands/help.ts)_
 <!-- commandsstop -->
+
+# Development
+
+## Building
+
+Build the CLI package into a `.tgz` file:
+
+```sh-session
+$ npm pack
+```
+
+This runs the `prepack` script automatically, which cleans the `lib/` directory, compiles TypeScript, and generates the oclif manifest. The output is a file like `aha-cli-v1.17.0.tgz`.
+
+## Testing a local build
+
+You can test the packaged CLI locally without installing it globally using `npx`:
+
+```sh-session
+$ npx --yes --package aha-cli-v1.17.0.tgz aha extension:watch
+```
+
+Replace `aha-cli-v1.17.0.tgz` with the actual filename produced by `npm pack`. Any `aha` command can be used this way, for example:
+
+```sh-session
+$ npx --yes --package aha-cli-v1.17.0.tgz aha extension:build
+$ npx --yes --package aha-cli-v1.17.0.tgz aha extension:install
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aha-cli",
   "description": "Command line interface for Aha! (www.aha.io)",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "Aha! (support@aha.io)",
   "bin": {
     "aha": "./bin/run"

--- a/src/utils/extension-utils.ts
+++ b/src/utils/extension-utils.ts
@@ -186,6 +186,7 @@ async function prepareExtensionForm(
   const jsxFactory = configuration.ahaExtension.jsxFactory || REACT_JSX;
   const jsxFragment = jsxFactory === REACT_JSX ? 'React.Fragment' : 'Fragment';
   const contributions = configuration.ahaExtension.contributes;
+  const peerDeps = Object.keys(configuration.peerDependencies || {});
   const scriptPaths: string[] = [];
   const cache = skipCache ? undefined : await SimpleCache.create('.aha-cache');
 
@@ -222,7 +223,8 @@ async function prepareExtensionForm(
           dumpCode,
           jsxFactory,
           jsxFragment,
-          cache
+          cache,
+          peerDeps
         );
       });
     })
@@ -262,7 +264,8 @@ async function prepareScript(
   dumpCode: boolean,
   jsxFactory: string,
   jsxFragment: string,
-  cache?: SimpleCache
+  cache?: SimpleCache,
+  peerDeps: string[] = []
 ) {
   // If no path is provided then this contribution has no script
   if (!path) {
@@ -275,9 +278,10 @@ async function prepareScript(
   }
 
   try {
-    const externalsFilter = EXTERNALS.map(
-      extern => `(^${extern}$)|(-/${extern}@)`
-    ).join('|');
+    const allExternals = [...new Set([...EXTERNALS, ...peerDeps])];
+    const externalsFilter = allExternals
+      .map(extern => `(^${extern}$)|(-/${extern}@)`)
+      .join('|');
 
     const bundle = await esbuild.build({
       jsxFactory,


### PR DESCRIPTION
Exclude defined peer dependencies when building extensions
We hard coded this list, but it should be based on peerDependencies. 

In the zendesk extension this code prevents aha-cli from bundling moment, zod & react-easy-state 

Before this change the built extension was 458K \
After its 27K


https://github.com/aha-develop/zendesk/blob/2cdba2cd7ff5a05b750b49ac10c64654de068379/package.json#L49-L53